### PR TITLE
Fix DB path resolution: create stockt.db relative to binary location

### DIFF
--- a/Inc/utils.h
+++ b/Inc/utils.h
@@ -8,6 +8,15 @@
 #ifndef UTILS_H
 #define UTILS_H
 
+/**
+ * @brief Obtient le chemin complet du fichier de base de données.
+ * Cette fonction construit le chemin complet du fichier de base de données
+ *  en utilisant le répertoire de l'exécutable courant et le nom du fichier de base
+ * de données fourni.   
+ * @param db_name Le nom du fichier de base de données.
+ * @return Le chemin complet du fichier de base de données.
+ */
+char* get_db_path(const char* db_name) ;
 
 /**
  * @brief Lit une chaîne de caractères depuis l'entrée standard.

--- a/Src/utils.c
+++ b/Src/utils.c
@@ -4,42 +4,65 @@
  * 
  * @author Oussama Amara
  * @date 2024-06-28
- * @version 1.0
+ * @version 1.1
  */
+
 #include <stdio.h>
 #include <string.h>
 #include <ctype.h>
 #include <stdlib.h>
 #include "utils.h"
 #include <errno.h>
+
+#ifdef _WIN32
+#include <windows.h>
+#else
 #include <unistd.h>
 #include <libgen.h>
+#include <limits.h>
+#endif
 
 /**
  * @brief Obtient le chemin complet du fichier de base de données.
- * Cette fonction construit le chemin complet du fichier de base de données
- * en utilisant le répertoire de l'exécutable courant et le nom du fichier de base              
- * de données fourni.
+ * Cette fonction utilise le chemin de l'exécutable courant pour construire
+ * le chemin absolu vers le fichier de base de données, assurant ainsi la portabilité
+ * entre les environnements Windows et Unix.
  * @param db_name Le nom du fichier de base de données.
- * @return Le chemin complet du fichier de base de données. 
- * Si une erreur se produit, retourne NULL.
- **/
+ * @return Le chemin complet du fichier de base de données, ou NULL en cas d'erreur.
+ */
 char* get_db_path(const char* db_name) {
     static char full_path[512];
     char exe_path[512];
 
+#ifdef _WIN32
+    DWORD len = GetModuleFileNameA(NULL, exe_path, sizeof(exe_path));
+    if (len == 0 || len >= sizeof(exe_path)) {
+        fprintf(stderr, "GetModuleFileNameA failed\n");
+        return NULL;
+    }
+    exe_path[len] = '\0';
+    char* exe_dir = strrchr(exe_path, '\\');
+    if (exe_dir) *(exe_dir + 1) = '\0';
+#else
     ssize_t len = readlink("/proc/self/exe", exe_path, sizeof(exe_path) - 1);
     if (len == -1) {
         perror("readlink");
         return NULL;
     }
-
     exe_path[len] = '\0';
     char* exe_dir = dirname(exe_path);
+#endif
 
-    snprintf(full_path, sizeof(full_path), "%s/%s", exe_dir, db_name);
+    snprintf(full_path, sizeof(full_path), "%s%s%s", exe_path,
+#ifdef _WIN32
+        "\\",
+#else
+        "/",
+#endif
+        db_name);
     return full_path;
 }
+
 
 /**
  * @brief Lit une chaîne de caractères depuis l'entrée standard.

--- a/Src/utils.c
+++ b/Src/utils.c
@@ -12,6 +12,35 @@
 #include <stdlib.h>
 #include "utils.h"
 #include <errno.h>
+#include <unistd.h>
+#include <libgen.h>
+
+/**
+ * @brief Obtient le chemin complet du fichier de base de données.
+ * Cette fonction construit le chemin complet du fichier de base de données
+ * en utilisant le répertoire de l'exécutable courant et le nom du fichier de base              
+ * de données fourni.
+ * @param db_name Le nom du fichier de base de données.
+ * @return Le chemin complet du fichier de base de données. 
+ * Si une erreur se produit, retourne NULL.
+ **/
+char* get_db_path(const char* db_name) {
+    static char full_path[512];
+    char exe_path[512];
+
+    ssize_t len = readlink("/proc/self/exe", exe_path, sizeof(exe_path) - 1);
+    if (len == -1) {
+        perror("readlink");
+        return NULL;
+    }
+
+    exe_path[len] = '\0';
+    char* exe_dir = dirname(exe_path);
+
+    snprintf(full_path, sizeof(full_path), "%s/%s", exe_dir, db_name);
+    return full_path;
+}
+
 /**
  * @brief Lit une chaîne de caractères depuis l'entrée standard.
  *

--- a/main.c
+++ b/main.c
@@ -86,7 +86,7 @@ int main(int argc, char *argv[]) {
     #endif
     sqlite3 *db;
     // Initialisation de la base de données
-    if (db_init(&db, "stock.db") != 0) {
+    if (db_init(&db, get_db_path("stockt.db")) != 0) {
         fprintf(stderr, "Impossible d'initialiser la base de données.\n");
         return 1;
     }


### PR DESCRIPTION
MR Description
This merge request modifies the database initialization logic to ensure stockt.db is always created in the same directory as the compiled binary (gestion_stock.exe), regardless of the current working directory during runtime.

🔧 Changes include:
Introduced dynamic path resolution using the executable location.

Ensures consistent DB placement for both manual runs and automated tests.

Improves test reliability and prevents stockt.db from being created in unintended folders (utils/, scripts/, etc.).

✅ Benefits:
Aligns runtime behavior with real-world deployments.

Simplifies file tracking during CI/CD.

Prevents cross-folder DB conflicts and improves isolation in test environments.